### PR TITLE
Focus the output view is on.

### DIFF
--- a/src/client/button.cpp
+++ b/src/client/button.cpp
@@ -1,6 +1,7 @@
 #include <cstdio>
 #include <getopt.h>
 #include <algorithm>
+#include <string>
 #include "wf-ctrl.hpp"
 
 void do_button(WfCtrl *wd, int argc, char *argv[])

--- a/src/plugin/wayfire-control.cpp
+++ b/src/plugin/wayfire-control.cpp
@@ -219,6 +219,7 @@ static void focus(struct wl_client *client, struct wl_resource *resource, int vi
         return;
     }
 
+    wf::get_core().focus_output(output);
     output->focus_view(view, true);
     output->workspace->request_workspace(
         output->workspace->get_view_main_workspace(view));


### PR DESCRIPTION
Hi,
Thanks for this tool. I was in need of something like this.

I realized that when using --focus, if the view is on a different monitor, the view becomes visible but it's not "focused" (as in, if I type the text doesn't appear on that terminal.)

Also, the compilation was failing on my system without the #include<string> directive.
